### PR TITLE
Improve use-package usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Clone this repo somewhere, and add this to your config:
 
 ```emacs-lisp
 (use-package flymake-ruff
-  :ensure t)
+  :ensure t
+  :hook (python-mode . flymake-ruff-load))
 ```
 
 ### Using straight.el

--- a/flymake-ruff.el
+++ b/flymake-ruff.el
@@ -12,6 +12,11 @@
 ;; Usage:
 ;;   (require 'flymake-ruff)
 ;;   (add-hook 'python-mode-hook #'flymake-ruff-load)
+;;
+;; Or, with use-package:
+;;   (use-package flymake-ruff
+;;     :ensure t
+;;     :hook (python-mode . flymake-ruff-load))
 
 ;;; Code:
 


### PR DESCRIPTION
This improves the instructions for using `flymake-ruff` with `use-package` by adding a hook.