### PR TITLE
change flymake-ruff-program-args for addition of `check` and removal of `text` (ruff 0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Flymake plugin to run a linter for python buffers using [ruff](https://github.co
 
 > Make sure you have at least `ruff` `0.1.0` version because there is a [breaking change](https://github.com/astral-sh/ruff/blob/main/BREAKING_CHANGES.md#010) in the output format flag
 
+> If you are using a version of `ruff` < `0.5.0`, set flymake-ruff-program-args to  `'("--output-format" "text" "--exit-zero" "--quiet" "-")`
 ## Installation
 
 ### Cloning the repo

--- a/flymake-ruff.el
+++ b/flymake-ruff.el
@@ -28,7 +28,7 @@
   :type 'string)
 
 (defcustom flymake-ruff-program-args
-  '("--output-format" "text" "--exit-zero" "--quiet" "-")
+  '("check" "--output-format" "concise" "--exit-zero" "--quiet" "-")
   "Flags to be given to \"ruff\"."
   :group 'flymake-ruff
   :type '(list string))


### PR DESCRIPTION
Small change so flymake-ruff is compatible with ruff 0.5.0 by default