### PR TITLE
Update output regex to work with newer versions

### DIFF
--- a/flymake-ruff.el
+++ b/flymake-ruff.el
@@ -33,7 +33,7 @@
   :group 'flymake-ruff
   :type '(list string))
 
-(defvar flymake-ruff--output-regex "\\(.*\\):\\([0-9]+\\):\\([0-9]+\\): \\([A-Za-z0-9]+\\): \\(.*\\)")
+(defvar flymake-ruff--output-regex "\\(.*\\):\\([0-9]+\\):\\([0-9]+\\): \\([A-Za-z0-9]+\\):? \\(.*\\)")
 
 (defconst flymake-ruff--default-configs
   '(".ruff.toml" "ruff.toml" "pyproject.toml")

--- a/flymake-ruff.el
+++ b/flymake-ruff.el
@@ -33,7 +33,7 @@
   :group 'flymake-ruff
   :type '(list string))
 
-(defvar flymake-ruff--output-regex "\\(.*\\):\\([0-9]+\\):\\([0-9]+\\): \\([A-Z0-9]+\\) \\(.*\\)")
+(defvar flymake-ruff--output-regex "\\(.*\\):\\([0-9]+\\):\\([0-9]+\\): \\([A-Za-z0-9]+\\): \\(.*\\)")
 
 (defconst flymake-ruff--default-configs
   '(".ruff.toml" "ruff.toml" "pyproject.toml")


### PR DESCRIPTION
Hello!

This PR aims to get the ruff output from version `0.6.9` (which is the latest as of writing this) working with `flymake-ruff`. I tested it on my local machine but feel free to give it a poke yourself ,and let me know if anything else needs changing.

Btw, thanks for the package!