### PR TITLE
Fix --stdin-filename option position

### DIFF
--- a/flymake-ruff.el
+++ b/flymake-ruff.el
@@ -70,7 +70,7 @@
                                  flymake-ruff-program-args))
                      flymake-ruff-program-args))
              (args (if code-filename
-                       (append `("--stdin-filename" ,code-filename) args)
+                       (append args `("--stdin-filename" ,code-filename))
                      args)))
         ;; call-process-region will run the program and replace current buffer
         ;; with its stdout, that's why we need to run it in a temporary buffer


### PR DESCRIPTION
Using the default `flymake-ruff-program-args', the command looks like this : ruff --stdin-filename <myfile> check <other args>

This command does not work with ruff 0.8.3

This commit seems to work on my side by placing the stdin-filename option at the end