### PR TITLE
Fix argument order so 'check' comes first

### DIFF
--- a/flymake-ruff.el
+++ b/flymake-ruff.el
@@ -70,7 +70,11 @@
                                  flymake-ruff-program-args))
                      flymake-ruff-program-args))
              (args (if code-filename
-                       (append `("--stdin-filename" ,code-filename) args)
+                       (if (member "check" flymake-ruff-program-args)
+                           (append `("check" "--stdin-filename" ,code-filename)
+                                   (cdr args))
+                         (append `("--stdin-filename" ,code-filename)
+                                 args))
                      args)))
         ;; call-process-region will run the program and replace current buffer
         ;; with its stdout, that's why we need to run it in a temporary buffer


### PR DESCRIPTION
This applies the same fix on the order of the arguments as the "--config" for the "--stdin-filename".

I tested for files outside of a project and for files in projects.