### PR TITLE
Allow flymake-ruff to use Ruff config files from remote TRAMP hosts

### DIFF
--- a/flymake-ruff.el
+++ b/flymake-ruff.el
@@ -35,6 +35,10 @@
 
 (defvar flymake-ruff--output-regex "\\(.*\\):\\([0-9]+\\):\\([0-9]+\\): \\([A-Za-z0-9]+\\):? \\(.*\\)")
 
+(defvar flymake-ruff--no-config-tramp-dirs
+  nil
+  "List of TRAMP directories that ruff checked for config in but found none. This prevents repeatedly looking for config files that do not exist.")
+
 (defconst flymake-ruff--default-configs
   '(".ruff.toml" "ruff.toml" "pyproject.toml")
   "Default configuration files supported by Ruff.")
@@ -42,30 +46,34 @@
 (defun flymake-ruff--get-config ()
   "Look for configuration files supported by Ruff in project root.
 When project is on remote host, cache config using `default-directory' as key."
-  (if (file-remote-p default-directory)
-      (let ((cache-dir (expand-file-name 
-                        (concat "ruff-config-" (sha1 default-directory))
-                        "/tmp")))
-        (if (file-directory-p cache-dir)
-            ;; Return cached config if exists
-            (seq-find #'file-readable-p
-                      (mapcar (lambda (f)
-				(expand-file-name f cache-dir))
-                              flymake-ruff--default-configs))
-          ;; Create cache and return config path
-	  (when-let* ((project-current (project-current))
+  (if (and (tramp-handle-file-remote-p default-directory))
+      (when (not (seq-contains-p flymake-ruff--no-config-tramp-dirs default-directory #'string-equal))
+	(let ((cache-dir (expand-file-name 
+                          (concat "ruff-config-" (sha1 default-directory))
+                          "/tmp")))
+          (if (file-directory-p cache-dir)
+              ;; Return cached config if exists
+              (seq-find #'file-readable-p
+			(mapcar (lambda (f)
+				  (expand-file-name f cache-dir))
+				flymake-ruff--default-configs))
+            ;; Create cache and return config path
+	    (if-let* ((project-current (project-current))
 		      (config (seq-find
                                #'tramp-handle-file-readable-p
                                (mapcar (lambda (f)
-                                         (expand-file-name f (project-root project-current)))
+                                         (tramp-handle-expand-file-name f (project-root project-current)))
 				       flymake-ruff--default-configs)))
-		      (temp-file (expand-file-name (file-name-nondirectory config) cache-dir))
+		      (temp-file (tramp-handle-expand-file-name (tramp-handle-file-name-nondirectory config) cache-dir))
 		      (temp-copy (tramp-handle-file-local-copy config)))
-	    (message "first")
-            (make-directory cache-dir)
-            (copy-file temp-copy temp-file t)
-            (delete-file temp-copy)
-            temp-file)))
+		(progn
+		  (make-directory cache-dir)
+		  (copy-file temp-copy temp-file t)
+		  (delete-file temp-copy)
+		  temp-file)
+	      (progn
+		(push default-directory flymake-ruff--no-config-tramp-dirs)
+		nil)))))
     
     ;; Local project path
     (when-let ((project-current (project-current)))

--- a/flymake-ruff.el
+++ b/flymake-ruff.el
@@ -46,7 +46,8 @@
 (defun flymake-ruff--get-config ()
   "Look for configuration files supported by Ruff in project root.
 When project is on remote host, cache config using `default-directory' as key."
-  (if (and (tramp-handle-file-remote-p default-directory))
+  (if (and (tramp-handle-file-remote-p (or buffer-file-name
+					   default-directory)))
       (when (not (seq-contains-p flymake-ruff--no-config-tramp-dirs default-directory #'string-equal))
 	(let ((cache-dir (expand-file-name 
                           (concat "ruff-config-" (sha1 default-directory))

--- a/flymake-ruff.el
+++ b/flymake-ruff.el
@@ -46,8 +46,8 @@
 (defun flymake-ruff--get-config ()
   "Look for configuration files supported by Ruff in project root.
 When project is on remote host, cache config using `default-directory' as key."
-  (if (and (tramp-handle-file-remote-p (or buffer-file-name
-					   default-directory)))
+  (if (tramp-handle-file-remote-p (or buffer-file-name
+				      default-directory))
       (when (not (seq-contains-p flymake-ruff--no-config-tramp-dirs default-directory #'string-equal))
 	(let ((cache-dir (expand-file-name 
                           (concat "ruff-config-" (sha1 default-directory))


### PR DESCRIPTION
`flymake-ruff` uses a local Ruff executable when checking a remote TRAMP file, which is preferable as the code checked is confined to the buffer and running commands over TRAMP can be slow. However, `flymake-ruff` tries to pass the full TRAMP path (i.e. `/ssh:remote:/path/to/pyproject.toml`) to Ruff as the config file location. This pull request copies the remote config file to `/tmp` on the local machine so that it can be passed to the Ruff executable. To stop TRAMP slowing to a crawl and prevent reentrant errors, the config is cached in tmp and can be refreshed by reverting the buffer.