### PR TITLE
Pass diagnostic description as list to fit Flymake columns

### DIFF
--- a/flymake-ruff.el
+++ b/flymake-ruff.el
@@ -113,7 +113,7 @@
                  (col (string-to-number (match-string 3)))
                  (code (match-string 4))
                  (msg (match-string 5))
-                 (description (format "Ruff: %s %s" code msg))
+                 (description (list "Ruff" code msg))
                  (region (flymake-diag-region code-buffer (1+ (- line start-line)) col))
                  (severity (flymake-ruff--severity-for-code code))
                  (dx (flymake-make-diagnostic code-buffer (car region) (cdr region)


### PR DESCRIPTION
Flymake supports the diagnostic info being passed as a list of `'(origin code msg)`  which then maps to the columns.

> INFO is a description of the problem detected.  It may be a string, or
list (ORIGIN CODE MESSAGE) appropriately categorizing and describing the
diagnostic.  ORIGIN may be a string or nil.  CODE maybe be a string, a
number or nil.  MESSAGE must be a string.

This changes it to use this functionality and end up consistent with Eglot LSP outputs

![image](https://github.com/user-attachments/assets/38468d7d-1fd2-4ea9-9a08-434eaf8bd48e)
