### PR TITLE
Fix syntax error in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ remove Pyright's "variable not accessed" notes, add the following:
                              (s-ends-with? "is not accessed" (flymake-diagnostic-text d))))
                       (car diags))))
 
-(advice-add 'eglot--report-to-flymake :filter-args #'my-filter-eglot-diagnostics))
+(advice-add 'eglot--report-to-flymake :filter-args #'my-filter-eglot-diagnostics)
 ```


### PR DESCRIPTION
I think there is one `)` too many. Copying the code block lead to a syntax error in my config.